### PR TITLE
Fix content-provider log parsing

### DIFF
--- a/src/main/java/com/jordansamhi/androlog/LogParser.java
+++ b/src/main/java/com/jordansamhi/androlog/LogParser.java
@@ -58,7 +58,7 @@ public class LogParser {
 
     private static String getType(String component) {
         String logType = null;
-        String[] logTypes = {"statements", "methods", "classes", "activities", "services", "broadcast-receivers"};
+        String[] logTypes = {"statements", "methods", "classes", "activities", "services", "broadcast-receivers", "content-providers"};
         for (String lt : logTypes) {
             if (component.startsWith(lt)) {
                 logType = lt;


### PR DESCRIPTION
This PR adds `content-providers` to the recognized log types in `LogParser.getType()`.

Previously, CONTENTPROVIDER log lines were not matched against visitedContentProviders because content-provider components were not recognized during parser initialization. This caused content-provider coverage to remain 0 even when matching log lines were present.